### PR TITLE
Change vst dirs to comply with LinuxAudio base extention

### DIFF
--- a/com.bitwig.BitwigStudio.yaml
+++ b/com.bitwig.BitwigStudio.yaml
@@ -35,7 +35,7 @@ finish-args:
   - --persist=Bitwig Studio
 
   - --env=ALSA_CONFIG_PATH=
-  - --env=VST_PATH=/app/extensions/Plugins/lxvst
+  - --env=VST_PATH=/app/extensions/Plugins/vst
   - --env=VST3_PATH=/app/extensions/Plugins/vst3
   - --env=CLAP_PATH=/app/extensions/Plugins/clap
 
@@ -52,7 +52,7 @@ add-extensions:
     directory: extensions/Plugins
     version: '22.08'
     add-ld-path: lib
-    merge-dirs: lxvst;vst3;clap
+    merge-dirs: vst;vst3;clap
     subdirectories: true
     no-autodownload: true
 


### PR DESCRIPTION
LinuxAudio base extention at some point changed 'lxvst' for VST2 plugins to just 'vst'. At the moment loading VST2 plugins installed as flatpaks is broken in Bitwig Studio. This fixes that.