### PR TITLE
Update All the Things to 23.08

### DIFF
--- a/com.bitwig.BitwigStudio.yaml
+++ b/com.bitwig.BitwigStudio.yaml
@@ -50,7 +50,7 @@ finish-args:
 add-extensions:
   org.freedesktop.LinuxAudio.Plugins:
     directory: extensions/Plugins
-    version: '22.08'
+    version: '23.08'
     add-ld-path: lib
     merge-dirs: vst;vst3;clap
     subdirectories: true
@@ -58,12 +58,12 @@ add-extensions:
 
   org.freedesktop.Platform.Compat.i386:
     directory: lib/i386-linux-gnu
-    version: '22.08'
+    version: '23.08'
 
   org.freedesktop.Platform.GL32:
     directory: lib/i386-linux-gnu/GL
     version: '1.4'
-    versions: 22.08;1.4
+    versions: 23.08;1.4
     subdirectories: true
     no-autodownload: true
     autodelete: false


### PR DESCRIPTION
Been using this fork for a while without any issues. Keeping some things on 22.08 causes problems with flatpaked plugins - they do not work if updated to 23.08.